### PR TITLE
letによる関数定義とそれに伴って発生する再帰関数に対応した。

### DIFF
--- a/src/Declar.hs
+++ b/src/Declar.hs
@@ -5,5 +5,6 @@ import Syntax
 
 decl :: Env -> Stmt -> (Env, String, Exval)
 decl env (Exp e)    = ( env, "-"        , eval env e)
-decl env (Decl s e) = (nenv, "val " ++ s, eval env e)
-  where nenv = (s, eval env e) : env
+decl env (Decl s e) = (nenv, "val " ++ s, fix_e)
+  where fix_e = FixV env s e
+        nenv  = (s, fix_e) : env

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -9,15 +9,16 @@ prim s = fromJust $ lookup s [("+", (+)), ("-", (-)), ("*", (*))]
 
 eval :: Env -> Expr -> Exval
 eval _ (Val i) = (ValV i)
-eval env (Var v) = fromJust $ lookup v env
+eval env (Var v) =
+    case fromJust $ lookup v env of
+      f@(FixV fenv s e) -> eval ((s, f) : fenv) e
+      exval             -> exval
 eval env (Prim f a b) =
   case (eval env a, eval env b) of
     (ValV x, ValV y) -> ValV $ prim f x y
     _ -> error "Eval.eval: Prim"
 eval env (Fun a b) = FunV env a b
-eval env (Fix s a b) = FixV env s a b
 eval env (App a b) =
   case eval env a of
-    FunV fenv x y       -> eval ((x, eval env b) : fenv) y
-    f@(FixV fenv s x y) -> eval ((s, f) : (x, eval env b) : fenv) y
+    FunV fenv x y -> eval ((x, eval env b) : fenv) y
     _ -> error "Eval.eval: App"

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -15,7 +15,9 @@ eval env (Prim f a b) =
     (ValV x, ValV y) -> ValV $ prim f x y
     _ -> error "Eval.eval: Prim"
 eval env (Fun a b) = FunV env a b
+eval env (Fix s a b) = FixV env s a b
 eval env (App a b) =
   case eval env a of
-    FunV fenv x y -> eval ((x, eval env b) : fenv) y
+    FunV fenv x y       -> eval ((x, eval env b) : fenv) y
+    f@(FixV fenv s x y) -> eval ((s, f) : (x, eval env b) : fenv) y
     _ -> error "Eval.eval: App"

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -55,15 +55,15 @@ stmtBody :: Parser Stmt
 stmtBody = liftM Exp expr <|> decl
 
 decl :: Parser Stmt
-decl =  symbol "let" >> (try fix <|> define)
+decl =  symbol "let" >> (try defun <|> define)
 
-fix :: Parser Stmt
-fix = do
+defun :: Parser Stmt
+defun = do
   name <- identifier
   arg  <- identifier
   reservedOp "="
   e <- expr
-  return $ Decl name (Fix name arg e)
+  return $ Decl name (Fun arg e)
 
 define :: Parser Stmt
 define = do

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -55,22 +55,15 @@ stmtBody :: Parser Stmt
 stmtBody = liftM Exp expr <|> decl
 
 decl :: Parser Stmt
-decl =  symbol "let" >> (try defun <|> define)
-
-defun :: Parser Stmt
-defun = do
+decl = do
+  _    <- symbol "let"  -- avoid unused-do-bind warning
   name <- identifier
-  arg  <- identifier
+  arg  <- option "" identifier
   reservedOp "="
   e <- expr
-  return $ Decl name (Fun arg e)
-
-define :: Parser Stmt
-define = do
-  name <- identifier
-  reservedOp "="
-  e <- expr
-  return $ Decl name e
+  return $ Decl name (case arg of
+                        "" -> e
+                        a  -> Fun a e)
 
 expr :: Parser Expr
 expr =  lambda

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -55,8 +55,18 @@ stmtBody :: Parser Stmt
 stmtBody = liftM Exp expr <|> decl
 
 decl :: Parser Stmt
-decl = do
-  symbol "let"
+decl =  symbol "let" >> (try fix <|> define)
+
+fix :: Parser Stmt
+fix = do
+  name <- identifier
+  arg  <- identifier
+  reservedOp "="
+  e <- expr
+  return $ Decl name (Fix name arg e)
+
+define :: Parser Stmt
+define = do
   name <- identifier
   reservedOp "="
   e <- expr

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -12,7 +12,6 @@ data Expr = Val  Int
           | Var  String
           | Prim String Expr Expr
           | Fun  String Expr
-          | Fix  String String Expr
           | App  Expr Expr
           deriving (Eq)
 
@@ -27,7 +26,7 @@ data Ty = TyInt
 
 data Exval = ValV Int
            | FunV Env String Expr
-           | FixV Env String String Expr
+           | FixV Env String Expr
            deriving (Eq)
 
 instance Show Expr where
@@ -35,7 +34,6 @@ instance Show Expr where
   show (Var s)      = s
   show (Prim f a b) = concat ["(Prim ", f, " ", show a, " ", show b, ")"]
   show (Fun a b)    = concat ["(\\", show a, " -> ", show b, ")"]
-  show (Fix s a b)  = concat ["(Fix ", show s, " \\", show a, " -> ", show b, ")"]
   show (App a b)    = concat ["(App", show a, ", ", show b, ")"]
 
 instance Show Ty where
@@ -45,4 +43,4 @@ instance Show Ty where
 instance Show Exval where
   show (ValV i) = show i
   show (FunV _ _ _) = "<fun>"
-  show (FixV _ _ _ _) = "<fix>"
+  show (FixV _ _ _) = "<fix>"

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -12,6 +12,7 @@ data Expr = Val  Int
           | Var  String
           | Prim String Expr Expr
           | Fun  String Expr
+          | Fix  String String Expr
           | App  Expr Expr
           deriving (Eq)
 
@@ -26,13 +27,15 @@ data Ty = TyInt
 
 data Exval = ValV Int
            | FunV Env String Expr
+           | FixV Env String String Expr
            deriving (Eq)
 
 instance Show Expr where
   show (Val i)      = show i
   show (Var s)      = s
-  show (Prim f a b) = concat ["(Prim", f, " ", show a, " ", show b, ")"]
+  show (Prim f a b) = concat ["(Prim ", f, " ", show a, " ", show b, ")"]
   show (Fun a b)    = concat ["(\\", show a, " -> ", show b, ")"]
+  show (Fix s a b)  = concat ["(Fix ", show s, " \\", show a, " -> ", show b, ")"]
   show (App a b)    = concat ["(App", show a, ", ", show b, ")"]
 
 instance Show Ty where
@@ -42,3 +45,4 @@ instance Show Ty where
 instance Show Exval where
   show (ValV i) = show i
   show (FunV _ _ _) = "<fun>"
+  show (FixV _ _ _ _) = "<fix>"

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -24,3 +24,6 @@ spec = do
 
     it "should return Decl with let" $ do
       parseStmt "let x = a" `shouldBe` (Right $ Decl "x" (Var "a"))
+
+    it "should return Decl with let" $ do
+      parseStmt "let f x = x + 1" `shouldBe` (Right $ Decl "f" (Fix "f" "x" (Prim "+" (Var "x") (Val 1))))

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -26,4 +26,4 @@ spec = do
       parseStmt "let x = a" `shouldBe` (Right $ Decl "x" (Var "a"))
 
     it "should return Decl with let" $ do
-      parseStmt "let f x = x + 1" `shouldBe` (Right $ Decl "f" (Fix "f" "x" (Prim "+" (Var "x") (Val 1))))
+      parseStmt "let f x = x + 1" `shouldBe` (Right $ Decl "f" (Fun "x" (Prim "+" (Var "x") (Val 1))))


### PR DESCRIPTION
始めに関数を評価する時はfenvに自分自身を入れることができないので、
FixVを用意して適用のたびに自分自身を環境に追加するという形で解決した。

再帰関数を停止させる手段がないのでEvalのテストは書いておらず、動作は保証されていない。